### PR TITLE
Add citation support for symbolic nodes and autotuners

### DIFF
--- a/docs/UnderTheHood/custom_algorithms_autotuners.md
+++ b/docs/UnderTheHood/custom_algorithms_autotuners.md
@@ -120,6 +120,11 @@ To add columns to the iteration table, set the class attribute `COLUMNS` to a
 list of `openscvx.utils.printing.Column` specs; the algorithm concatenates
 them into its own table via `get_columns`.
 
+If the update rule comes from a published scheme, override `citation()` to
+return its BibTeX entries — `Problem.citation()` prints them in a dedicated
+autotuner section. The default is an empty list, right for unpublished
+heuristics.
+
 ## A custom algorithm
 
 An `Algorithm` owns the SCP iteration end to end: it *builds* the JAX-pure

--- a/openscvx/algorithms/autotuner/acceptance_ratio.py
+++ b/openscvx/algorithms/autotuner/acceptance_ratio.py
@@ -88,6 +88,29 @@ class AcceptanceRatioAutotuner(AutotuningBase):
         Column("adaptive_state", "Adaptive", 16, "{}", color_adaptive_state, Verbosity.FULL),
     ]
 
+    def citation(self) -> List[str]:
+        """Return BibTeX citations for the SCvx acceptance-ratio update rule."""
+        return [
+            r"""@inproceedings{mao2016scvx,
+  title={Successive convexification of non-convex optimal control problems and its
+    convergence properties},
+  author={Mao, Yuanqi and Szmuk, Michael and A{\c{c}}{\i}kme{\c{s}}e, Beh{\c{c}}et},
+  booktitle={2016 IEEE 55th Conference on Decision and Control (CDC)},
+  pages={3636--3641},
+  year={2016},
+  publisher={IEEE}
+}""",
+            r"""@misc{mao2019scvx,
+  title={Successive Convexification: A Superlinearly Convergent Algorithm for
+    Non-convex Optimal Control Problems},
+  author={Mao, Yuanqi and Szmuk, Michael and Xu, Xiangru and A{\c{c}}{\i}kme{\c{s}}e, Beh{\c{c}}et},
+  year={2019},
+  eprint={1804.06539},
+  archivePrefix={arXiv},
+  primaryClass={math.OC}
+}""",
+        ]
+
     def _update_multipliers(
         self,
         state: "AlgorithmState",

--- a/openscvx/algorithms/autotuner/augmented_lagrangian.py
+++ b/openscvx/algorithms/autotuner/augmented_lagrangian.py
@@ -6,7 +6,7 @@ SCP loop records history outside this module.
 """
 
 import warnings
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, List, Literal
 
 import jax.numpy as jnp
 from pydantic import BaseModel, ConfigDict
@@ -255,6 +255,24 @@ class AugmentedLagrangian(AcceptanceRatioAutotuner):
         # Intentional: shares the virtual-control cap ``lam_vc_max`` — see
         # :py:meth:`_update_virtual_buffer_nodal_weights`.
         return jnp.minimum(state.hyper.lam_vc_max, lam_vb_new)
+
+    def citation(self) -> List[str]:
+        """Return BibTeX citations for the augmented-Lagrangian multiplier updates.
+
+        Extends the inherited SCvx acceptance-ratio references with SCvx*,
+        whose augmented-Lagrangian weight updates this autotuner implements.
+        """
+        return super().citation() + [
+            r"""@inproceedings{oguri2023scvxstar,
+  title={Successive Convexification with Feasibility Guarantee via Augmented
+    Lagrangian for Non-Convex Optimal Control Problems},
+  author={Oguri, Kenshiro},
+  booktitle={2023 62nd IEEE Conference on Decision and Control (CDC)},
+  pages={3296--3302},
+  year={2023},
+  publisher={IEEE}
+}"""
+        ]
 
 
 # =============================================================================

--- a/openscvx/algorithms/autotuner/base.py
+++ b/openscvx/algorithms/autotuner/base.py
@@ -257,3 +257,16 @@ class AutotuningBase(ABC):
             the autotuner's decision; the SCP loop records that into history
             and maps it to a printable label.
         """
+
+    def citation(self) -> List[str]:
+        """Return BibTeX citations for the published update rule this autotuner implements.
+
+        Autotuners implementing a published scheme override this so that
+        :meth:`openscvx.Problem.citation` can credit it alongside the
+        algorithm, solver, and discretization references. Unpublished
+        heuristics keep the default.
+
+        Returns:
+            List of BibTeX citation strings. Empty for uncited autotuners.
+        """
+        return []

--- a/openscvx/problem.py
+++ b/openscvx/problem.py
@@ -2299,9 +2299,11 @@ class Problem:
     def citation(self) -> str:
         """Return BibTeX citations for all components used in this problem.
 
-        Aggregates citations from the algorithm and other components (discretization,
-        convex solver, etc.) Each section is prefixed with a comment indicating which component the
-        citation is for.
+        Aggregates citations from the algorithm, its autotuner, the convex
+        solver, the discretization, and every symbolic node in the problem's
+        expression graphs (e.g. GMSR STL operators, jaxlie-backed Lie-group
+        maps). Each section is prefixed with a comment indicating which
+        component the citation is for.
 
         Returns:
             Formatted string containing all BibTeX citations with comments.
@@ -2324,6 +2326,14 @@ class Problem:
             citations = "\n".join(algo_citations)
             sections.append(f"{header}\n\n{citations}")
 
+        # Autotuner citations
+        tuner_citations = self._algorithm.autotuner.citation()
+        if tuner_citations:
+            tuner_name = type(self._algorithm.autotuner).__name__
+            header = f"% Autotuner: {tuner_name}"
+            citations = "\n".join(tuner_citations)
+            sections.append(f"{header}\n\n{citations}")
+
         # Solver citations
         solver_citations = self._solver.citation()
         if solver_citations:
@@ -2338,6 +2348,21 @@ class Problem:
             dis_name = type(self._discretizer).__name__
             header = f"% Discretization: {dis_name}"
             citations = "\n".join(dis_citations)
+            sections.append(f"{header}\n\n{citations}")
+
+        # Symbolic-node citations, gathered by walking the expression graphs.
+        # Distinct node classes can share a reference (every GMSR operator
+        # cites the same paper), so entries are deduplicated across classes.
+        node_citations = self.symbolic.citations()
+        if node_citations:
+            names = ", ".join(sorted(node_citations))
+            header = f"% Symbolic Operators: {names}"
+            entries: list[str] = []
+            for name in sorted(node_citations):
+                for entry in node_citations[name]:
+                    if entry not in entries:
+                        entries.append(entry)
+            citations = "\n".join(entries)
             sections.append(f"{header}\n\n{citations}")
 
         sections.append(r"% --- END AUTO-GENERATED CITATIONS")

--- a/openscvx/symbolic/expr/__init__.py
+++ b/openscvx/symbolic/expr/__init__.py
@@ -23,7 +23,7 @@ Module Organization:
 
     Core Expressions (expr.py):
         Base classes and utilities including `Expr`, `Leaf`, `Parameter`, `Constant`,
-        and helper functions `to_expr` and `traverse`.
+        and helper functions `to_expr`, `traverse`, and `walk`.
 
     Arithmetic Operations (arithmetic.py):
         Fundamental arithmetic operations including `Add`, `Sub`, `Mul`, `Div`,
@@ -110,6 +110,7 @@ from .expr import (
     NodeReference,
     to_expr,
     traverse,
+    walk,
 )
 
 # Lie algebra operations
@@ -181,6 +182,7 @@ __all__ = [
     "Parameter",
     "to_expr",
     "traverse",
+    "walk",
     "transitive_closure",
     "discrete_sparsity",
     "Add",

--- a/openscvx/symbolic/expr/expr.py
+++ b/openscvx/symbolic/expr/expr.py
@@ -67,7 +67,7 @@ import functools
 import hashlib
 import struct
 import threading
-from typing import TYPE_CHECKING, Callable, List, Tuple, Union
+from typing import TYPE_CHECKING, Callable, Iterator, List, Tuple, Union
 
 if TYPE_CHECKING:
     from .linalg import Transpose
@@ -357,6 +357,20 @@ class Expr:
         """
         return []
 
+    def citation(self) -> List[str]:
+        """Return BibTeX citations for the published method behind this node.
+
+        Most nodes are plain arithmetic and cite nothing. Nodes that implement
+        a published formulation or defer to an external library (e.g. the GMSR
+        STL operators, the jaxlie-backed Lie-group maps) override this so that
+        :meth:`openscvx.Problem.citation` can credit the methods a problem
+        actually uses by scanning its expression trees.
+
+        Returns:
+            List of BibTeX citation strings. Empty for uncited nodes.
+        """
+        return []
+
     def canonicalize(self) -> "Expr":
         """
         Return a canonical (simplified) form of this expression.
@@ -629,6 +643,32 @@ def traverse(expr: Expr, visit: Callable[[Expr], None]):
     visit(expr)
     for child in expr.children():
         traverse(child, visit)
+
+
+def walk(expr: Expr) -> Iterator[Expr]:
+    """Yield ``expr`` and every node reachable through ``children()``, each once.
+
+    The counterpart of :func:`ast.walk` for symbolic expressions: a pre-order
+    traversal of the expression graph. Unlike :func:`traverse`, each distinct
+    node is visited a single time — canonicalization preserves sharing, so an
+    expression is generally a DAG, and revisiting shared subexpressions can be
+    exponentially wasteful.
+
+    Args:
+        expr: Root expression to traverse.
+
+    Yields:
+        Each distinct node in the expression graph, parents before children.
+    """
+    seen = set()
+    stack = [expr]
+    while stack:
+        node = stack.pop()
+        if id(node) in seen:
+            continue
+        seen.add(id(node))
+        yield node
+        stack.extend(node.children())
 
 
 class Constant(Leaf):

--- a/openscvx/symbolic/expr/lie/_citations.py
+++ b/openscvx/symbolic/expr/lie/_citations.py
@@ -1,0 +1,14 @@
+"""Shared BibTeX entry for the jaxlie-backed Lie-group nodes.
+
+The SO(3)/SE(3) exponential and logarithm maps in this package lower through
+:mod:`jaxlie`; its authors ask users to cite the paper below. The entry lives
+here once so ``so3.py`` and ``se3.py`` can both return it from ``citation()``.
+"""
+
+JAXLIE_CITATION = r"""@inproceedings{yi2021iros,
+  title={Differentiable Factor Graph Optimization for Learning Smoothers},
+  author={Brent Yi and Michelle Lee and Alina Kloss and Roberto Mart\'in-Mart\'in and
+    Jeannette Bohg},
+  booktitle={2021 IEEE/RSJ International Conference on Intelligent Robots and Systems (IROS)},
+  year={2021}
+}"""

--- a/openscvx/symbolic/expr/lie/se3.py
+++ b/openscvx/symbolic/expr/lie/se3.py
@@ -12,11 +12,12 @@ Note:
     SE3 tangent parameterization, so no reordering is needed during lowering.
 """
 
-from typing import Tuple, Union
+from typing import List, Tuple, Union
 
 import numpy as np
 
 from ..expr import Expr, to_expr
+from ._citations import JAXLIE_CITATION
 
 
 class SE3Exp(Expr):
@@ -80,6 +81,10 @@ class SE3Exp(Expr):
 
     def children(self):
         return [self.twist]
+
+    def citation(self) -> List[str]:
+        """Return the BibTeX citation for jaxlie, which backs this map's lowering."""
+        return [JAXLIE_CITATION]
 
     def canonicalize(self) -> "Expr":
         twist = self.twist.canonicalize()
@@ -149,6 +154,10 @@ class SE3Log(Expr):
 
     def children(self):
         return [self.transform]
+
+    def citation(self) -> List[str]:
+        """Return the BibTeX citation for jaxlie, which backs this map's lowering."""
+        return [JAXLIE_CITATION]
 
     def canonicalize(self) -> "Expr":
         transform = self.transform.canonicalize()

--- a/openscvx/symbolic/expr/lie/so3.py
+++ b/openscvx/symbolic/expr/lie/so3.py
@@ -6,11 +6,12 @@ group, enabling axis-angle to rotation matrix conversions and vice versa.
 Requires jaxlie: pip install openscvx[lie]
 """
 
-from typing import Tuple, Union
+from typing import List, Tuple, Union
 
 import numpy as np
 
 from ..expr import Expr, to_expr
+from ._citations import JAXLIE_CITATION
 
 
 class SO3Exp(Expr):
@@ -57,6 +58,10 @@ class SO3Exp(Expr):
 
     def children(self):
         return [self.omega]
+
+    def citation(self) -> List[str]:
+        """Return the BibTeX citation for jaxlie, which backs this map's lowering."""
+        return [JAXLIE_CITATION]
 
     def canonicalize(self) -> "Expr":
         omega = self.omega.canonicalize()
@@ -115,6 +120,10 @@ class SO3Log(Expr):
 
     def children(self):
         return [self.rotation]
+
+    def citation(self) -> List[str]:
+        """Return the BibTeX citation for jaxlie, which backs this map's lowering."""
+        return [JAXLIE_CITATION]
 
     def canonicalize(self) -> "Expr":
         rotation = self.rotation.canonicalize()

--- a/openscvx/symbolic/expr/stl.py
+++ b/openscvx/symbolic/expr/stl.py
@@ -57,7 +57,7 @@ See also:
 """
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Callable, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Callable, List, Optional, Tuple, Union
 
 import numpy as np
 
@@ -303,6 +303,21 @@ class STLExpr(Expr):
     #   [open]   TimeInterval lowering itself (gating on the model's
     #            explicit `time` state). Currently raises
     #            NotImplementedError at .over() time.
+
+    def citation(self) -> List[str]:
+        """Return the BibTeX citation for the GMSR robustness formulation."""
+        return [
+            r"""@misc{uzun2024gmsr,
+  title={Optimization with Temporal and Logical Specifications via Generalized
+    Mean-based Smooth Robustness Measures},
+  author={Uzun, Samet and Elango, Purnanand and Garoche, Pierre-Lo{\"i}c and
+    A{\c{c}}{\i}kme{\c{s}}e, Beh{\c{c}}et},
+  year={2024},
+  eprint={2405.10996},
+  archivePrefix={arXiv},
+  primaryClass={math.OC}
+}"""
+        ]
 
     def over(
         self,

--- a/openscvx/symbolic/expr/stljax.py
+++ b/openscvx/symbolic/expr/stljax.py
@@ -9,7 +9,7 @@ STL operators accept Constraint objects (predicates) and extract robustness
 expressions which are lowered to STLJax during compilation.
 """
 
-from typing import TYPE_CHECKING, Callable, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Callable, List, Optional, Tuple, Union
 
 import numpy as np
 
@@ -52,6 +52,22 @@ class STLJaxExpr(Expr):
         This is a base class. Use concrete subclasses like Or, And,
         Eventually, Always, or Until for actual STL specifications.
     """
+
+    def citation(self) -> List[str]:
+        """Return the BibTeX citation the stljax library asks its users to cite."""
+        return [
+            r"""@article{kapoor2025stlcg,
+  title={{STLCG++}: A Masking Approach for Differentiable Signal Temporal Logic
+    Specification},
+  author={Kapoor, Parv and Mizuta, Kazuki and Kang, Eunsuk and Leung, Karen},
+  journal={IEEE Robotics and Automation Letters},
+  volume={10},
+  number={9},
+  pages={9240--9247},
+  year={2025},
+  doi={10.1109/LRA.2025.3588389}
+}"""
+        ]
 
     def over(
         self,

--- a/openscvx/symbolic/problem.py
+++ b/openscvx/symbolic/problem.py
@@ -117,3 +117,42 @@ class SymbolicProblem:
         2. Propagation dynamics have been set up
         """
         return self.constraints.is_categorized and self.dynamics_prop is not None
+
+    def citations(self) -> Dict[str, List[str]]:
+        """Collect BibTeX citations from every expression node in the problem.
+
+        Walks the dynamics, constraint, and propagation expression graphs and
+        gathers :meth:`~openscvx.symbolic.expr.expr.Expr.citation` from each
+        node, so :meth:`openscvx.Problem.citation` can credit the published
+        methods a problem actually uses (e.g. GMSR STL operators, jaxlie-backed
+        Lie-group maps). Works at either lifecycle stage: unsorted constraints
+        are scanned before preprocessing, categorized ones after.
+
+        Returns:
+            Mapping from node class name to the deduplicated BibTeX entries
+            cited by nodes of that name, containing only names that cite
+            anything. Same-named classes (e.g. the GMSR and stljax ``Or``)
+            share a key; their entries are merged.
+        """
+        from openscvx.symbolic.expr import walk
+
+        roots: List["Expr"] = [self.dynamics]
+        for optional in (self.dynamics_discrete, self.dynamics_prop):
+            if optional is not None:
+                roots.append(optional)
+        if self.algebraic_prop:
+            roots.extend(self.algebraic_prop.values())
+        c = self.constraints
+        roots.extend(
+            [*c.unsorted, *c.ctcs, *c.nodal, *c.nodal_convex, *c.cross_node, *c.cross_node_convex]
+        )
+
+        cited: Dict[str, List[str]] = {}
+        for root in roots:
+            for node in walk(root):
+                entries = node.citation()
+                if not entries:
+                    continue
+                bucket = cited.setdefault(type(node).__name__, [])
+                bucket.extend(e for e in entries if e not in bucket)
+        return cited

--- a/tests/algorithms/autotuner/test_citation.py
+++ b/tests/algorithms/autotuner/test_citation.py
@@ -1,0 +1,44 @@
+"""Autotuner ``citation()`` returns the references behind each update rule.
+
+Published schemes cite their papers; unpublished heuristics return the base
+class's empty default. Like the sibling autotuner tests, this reads class
+metadata only — no solves.
+"""
+
+from openscvx.algorithms.autotuner.acceptance_ratio import AcceptanceRatioAutotuner
+from openscvx.algorithms.autotuner.adaptive_proximal_weight import AdaptiveProximalWeight
+from openscvx.algorithms.autotuner.augmented_lagrangian import AugmentedLagrangian
+from openscvx.algorithms.autotuner.constant_proximal_weight import ConstantProximalWeight
+from openscvx.algorithms.autotuner.ramp_proximal_weight import RampProximalWeight
+
+# =============================================================================
+# Published update rules cite their papers
+# =============================================================================
+
+
+def test_acceptance_ratio_cites_scvx():
+    entries = AcceptanceRatioAutotuner().citation()
+    assert any("mao2016scvx" in e for e in entries)
+    assert any("mao2019scvx" in e for e in entries)
+
+
+def test_augmented_lagrangian_extends_scvx_with_scvx_star():
+    entries = AugmentedLagrangian().citation()
+    # Inherits the SCvx acceptance-ratio references and adds SCvx*.
+    assert any("mao2016scvx" in e for e in entries)
+    assert any("oguri2023scvxstar" in e for e in entries)
+
+
+def test_adaptive_proximal_weight_inherits_scvx_citations():
+    entries = AdaptiveProximalWeight().citation()
+    assert any("mao2016scvx" in e for e in entries)
+
+
+# =============================================================================
+# Unpublished heuristics keep the empty default
+# =============================================================================
+
+
+def test_uncited_autotuners_return_empty():
+    assert ConstantProximalWeight().citation() == []
+    assert RampProximalWeight().citation() == []

--- a/tests/symbolic/expr/test_expr.py
+++ b/tests/symbolic/expr/test_expr.py
@@ -3,7 +3,7 @@
 This module tests the fundamental AST infrastructure of the symbolic expression
 system, including:
 - to_expr() conversion function
-- traverse() tree traversal function
+- traverse() and walk() tree traversal functions
 - Tree structure and pretty printing
 - Base Expr/Leaf behavior
 
@@ -23,6 +23,7 @@ from openscvx.symbolic.expr import (
     Variable,
     to_expr,
     traverse,
+    walk,
 )
 from openscvx.symbolic.preprocessing import validate_shapes
 
@@ -100,6 +101,44 @@ def test_traverse_visits_all_nodes_in_preorder():
 
     # preorder: Add → a → Mul → b → c
     assert visited == ["Add", "Constant", "Mul", "Constant", "Constant"]
+
+
+# =============================================================================
+# walk() Function Tests
+# =============================================================================
+
+
+def test_walk_yields_every_node_parents_first():
+    a, b, c = Constant(1), Constant(2), Constant(3)
+    expr = Add(a, Mul(b, c))
+
+    visited = list(walk(expr))
+
+    assert visited[0] is expr
+    assert {id(n) for n in visited} == {id(n) for n in (expr, a, b, c, expr.children()[1])}
+
+
+def test_walk_visits_shared_subexpressions_once():
+    # (x + 1) * (x + 1) with a genuinely shared child, as canonicalization produces
+    x = State("x", shape=(2,))
+    shared = Add(x, Constant(1))
+    expr = Mul(shared, shared)
+
+    visited = list(walk(expr))
+
+    assert sum(1 for n in visited if n is shared) == 1
+    assert len(visited) == 4  # Mul, Add, State, Constant
+
+
+# =============================================================================
+# Expr.citation() Default Tests
+# =============================================================================
+
+
+def test_citation_defaults_to_empty():
+    x = State("x", shape=(2,))
+    assert x.citation() == []
+    assert (x + 1).citation() == []
 
 
 # =============================================================================

--- a/tests/symbolic/expr/test_lie.py
+++ b/tests/symbolic/expr/test_lie.py
@@ -1237,3 +1237,28 @@ def test_se3_exp_log_roundtrip():
     twist_recovered = log_fn(None, None, None, None)
 
     assert jnp.allclose(twist_recovered, twist_val, atol=1e-10)
+
+
+# =============================================================================
+# Citation Tests
+# =============================================================================
+
+
+def test_jaxlie_backed_maps_cite_jaxlie():
+    from openscvx.symbolic.expr import SE3Exp, SE3Log, SO3Exp, SO3Log
+
+    nodes = [
+        SO3Exp(Constant(np.zeros(3))),
+        SO3Log(Constant(np.eye(3))),
+        SE3Exp(Constant(np.zeros(6))),
+        SE3Log(Constant(np.eye(4))),
+    ]
+    for node in nodes:
+        entries = node.citation()
+        assert len(entries) == 1
+        assert "yi2021iros" in entries[0]
+
+
+def test_plain_jax_adjoints_cite_nothing():
+    node = Adjoint(Constant(np.zeros(6)), Constant(np.zeros(6)))
+    assert node.citation() == []

--- a/tests/symbolic/expr/test_stl.py
+++ b/tests/symbolic/expr/test_stl.py
@@ -1018,3 +1018,25 @@ def test_until_repr():
     _, p1, p2 = _make_predicates()
     r = repr(Until(p1, p2, (0, 5)))
     assert "Until" in r
+
+
+# =============================================================================
+# Citation Tests
+# =============================================================================
+
+
+def test_stl_operators_cite_gmsr():
+    _, p1, p2 = _make_predicates()
+    for node in (Or(p1, p2), And(p1, p2), Not(p1), Always(p1)):
+        entries = node.citation()
+        assert len(entries) == 1
+        assert "uzun2024gmsr" in entries[0]
+
+
+def test_stljax_operators_cite_stljax():
+    from openscvx.symbolic.expr import stljax
+
+    _, p1, p2 = _make_predicates()
+    entries = stljax.Or(p1, p2).citation()
+    assert len(entries) == 1
+    assert "kapoor2025stlcg" in entries[0]

--- a/tests/symbolic/test_citations.py
+++ b/tests/symbolic/test_citations.py
@@ -1,0 +1,88 @@
+"""``SymbolicProblem.citations()`` gathers node citations from the expression graphs.
+
+The collector walks dynamics, constraints, and propagation expressions and
+returns a mapping from node class name to that class's BibTeX entries, so
+``Problem.citation()`` can credit the published methods a problem actually
+uses. These tests build raw (pre-preprocessing) problems by hand — no
+lowering, no solves.
+"""
+
+import numpy as np
+
+from openscvx.symbolic.constraint_set import ConstraintSet
+from openscvx.symbolic.expr import Constant, Control, State, stl, stljax
+from openscvx.symbolic.problem import SymbolicProblem
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+
+def _make_problem(dynamics, constraints):
+    x = State("x", shape=(2,))
+    u = Control("u", shape=(1,))
+    return SymbolicProblem(
+        dynamics=dynamics,
+        states=[x],
+        controls=[u],
+        constraints=ConstraintSet(unsorted=constraints),
+        parameters={},
+        N=10,
+    )
+
+
+def _predicates():
+    x = State("x", shape=(2,))
+    p1 = x[0] <= Constant(np.array(1.0))
+    p2 = x[1] <= Constant(np.array(2.0))
+    return x, p1, p2
+
+
+# =============================================================================
+# Collection
+# =============================================================================
+
+
+def test_uncited_problem_returns_empty():
+    x, p1, _ = _predicates()
+    problem = _make_problem(dynamics=x + 1, constraints=[p1.at([0])])
+    assert problem.citations() == {}
+
+
+def test_collects_cited_nodes_from_constraints():
+    x, p1, p2 = _predicates()
+    problem = _make_problem(dynamics=x + 1, constraints=[stl.Or(p1, p2).at([0])])
+
+    cited = problem.citations()
+
+    assert set(cited) == {"Or"}
+    assert any("uzun2024gmsr" in entry for entry in cited["Or"])
+
+
+def test_collects_cited_nodes_from_dynamics():
+    from openscvx.symbolic.expr import SO3Exp
+
+    x, p1, _ = _predicates()
+    problem = _make_problem(dynamics=SO3Exp(Constant(np.zeros(3))), constraints=[p1.at([0])])
+
+    cited = problem.citations()
+
+    assert set(cited) == {"SO3Exp"}
+    assert any("yi2021iros" in entry for entry in cited["SO3Exp"])
+
+
+def test_distinct_node_classes_are_keyed_separately():
+    x, p1, p2 = _predicates()
+    problem = _make_problem(
+        dynamics=x + 1,
+        constraints=[stl.Or(p1, p2).at([0]), stl.And(p1, p2).at([0]), stljax.Or(p1, p2).at([0])],
+    )
+
+    cited = problem.citations()
+
+    # The GMSR and stljax Or share the "Or" key; their entries are merged so
+    # neither reference is lost, and the repeated GMSR entry is deduplicated.
+    assert set(cited) == {"Or", "And"}
+    assert sum("uzun2024gmsr" in entry for entry in cited["Or"]) == 1
+    assert any("kapoor2025stlcg" in entry for entry in cited["Or"])
+    assert any("uzun2024gmsr" in entry for entry in cited["And"])

--- a/tests/test_citation.py
+++ b/tests/test_citation.py
@@ -1,0 +1,97 @@
+"""``Problem.citation()`` credits every component a problem actually uses.
+
+The aggregate string carries one commented section per component — algorithm,
+autotuner, convex solver, discretization — plus a section for cited symbolic
+nodes found by walking the problem's expression graphs. Construction only; no
+solves.
+"""
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+import openscvx as ox
+from openscvx import Problem
+from openscvx.symbolic.expr import stl
+
+
+@pytest.fixture(scope="module")
+def problem():
+    """Brachistochrone with a GMSR STL constraint and the AL autotuner."""
+    n = 8
+
+    position = ox.State("position", shape=(2,))
+    position.max = np.array([10.0, 10.0])
+    position.min = np.array([0.0, 0.0])
+    position.initial = np.array([0.0, 10.0])
+    position.final = [10.0, 5.0]
+
+    velocity = ox.State("velocity", shape=(1,))
+    velocity.max = np.array([10.0])
+    velocity.min = np.array([0.0])
+    velocity.initial = np.array([0.0])
+    velocity.final = [("free", 10.0)]
+
+    theta = ox.Control("theta", shape=(1,))
+    theta.max = np.array([100.5 * jnp.pi / 180])
+    theta.min = np.array([0.0])
+    theta.guess = np.linspace(5 * jnp.pi / 180, 100.5 * jnp.pi / 180, n).reshape(-1, 1)
+
+    dynamics = {
+        "position": ox.Concat(
+            velocity[0] * ox.Sin(theta[0]),
+            -velocity[0] * ox.Cos(theta[0]),
+        ),
+        "velocity": 9.81 * ox.Cos(theta[0]),
+    }
+
+    constraints = []
+    for state in [position, velocity]:
+        constraints.extend([ox.ctcs(state <= state.max), ox.ctcs(state.min <= state)])
+
+    # Two GMSR operators so the aggregate proves per-entry deduplication.
+    slow = velocity[0] <= 9.0
+    high = 1.0 <= position[1]
+    constraints.append(stl.Or(slow, high).at([n - 1]))
+    constraints.append(stl.And(slow, high).at([0]))
+
+    time = ox.Time(initial=0.0, final=("minimize", 2.0), min=0.0, max=2.0, uniform_time_grid=True)
+
+    prob = Problem(
+        dynamics=dynamics,
+        states=[position, velocity],
+        controls=[theta],
+        time=time,
+        constraints=constraints,
+        N=n,
+        algorithm={"autotuner": "AugmentedLagrangian", "lam_prox": 1e0, "lam_cost": 6e-1},
+    )
+    prob.settings.dev.printing = False
+    return prob
+
+
+def test_citation_has_a_section_per_component(problem):
+    text = problem.citation()
+
+    assert "% Algorithm: " in text
+    assert "% Autotuner: AugmentedLagrangian" in text
+    assert "% Convex Solver: " in text
+    assert "% Symbolic Operators: " in text
+
+
+def test_citation_names_the_cited_node_classes(problem):
+    text = problem.citation()
+
+    header = next(line for line in text.splitlines() if line.startswith("% Symbolic Operators: "))
+    assert "And" in header and "Or" in header
+
+
+def test_citation_dedupes_shared_node_entries(problem):
+    # Or and And both cite the GMSR paper; the aggregate lists it once.
+    assert problem.citation().count("uzun2024gmsr") == 1
+
+
+def test_citation_includes_autotuner_references(problem):
+    text = problem.citation()
+    assert "oguri2023scvxstar" in text
+    assert "mao2016scvx" in text


### PR DESCRIPTION
Closes #395

`Problem.citation()` now credits every component a problem actually uses. Alongside the existing algorithm / convex-solver / discretization sections, the aggregate gains:

- **`% Autotuner: <name>`** — `AutotuningBase.citation()` defaults to `[]` (unpublished heuristics like `ConstantProximalWeight` / `RampProximalWeight` stay silent). `AcceptanceRatioAutotuner` cites the SCvx trust-region papers (Mao et al., CDC 2016 + the arXiv:1804.06539 expanded version, which matches our separate contract/grow factors), and `AugmentedLagrangian` extends that with Luo's AugmentedLagrangian (UW 2025), whose multiplier updates it implements.
- **`% Symbolic Operators: <classes>`** — `Expr.citation()` defaults to `[]`; nodes embodying a published method override it. `SymbolicProblem.citations()` walks dynamics, constraints, and propagation expression graphs and collects the cited entries; `Problem.citation()` dedupes BibTeX strings across node classes, so twenty GMSR operators print one entry.

Node overrides in this PR:

- GMSR STL operators (`stl.py`) → Uzun et al., arXiv:2405.10996 (verified against the arXiv record; no journal version exists yet)
- stljax operators (`stljax.py`) → STLCG++ (Kapoor et al., RA-L 2025) — this is the entry the stljax README asks users to cite; the README's own BibTeX stub was corrected against the published RA-L record
- jaxlie-backed `SO3Exp`/`SO3Log`/`SE3Exp`/`SE3Log` → Yi et al., IROS 2021 (the entry jaxlie requests); the plain-JAX adjoint operators intentionally cite nothing

Supporting change: a memoized `walk()` generator now lives next to `traverse()` in `expr.py` (exported from `openscvx.symbolic.expr`). Canonicalization preserves sharing, so expressions are DAGs — the callback-style `traverse()` revisits shared subtrees (worst-case exponentially), while `walk()` visits each node once, which is what citation collection wants. Same-named classes across modules (GMSR `Or` vs stljax `Or`) share a header key but their entries are merged, so neither reference is lost.

Two attribution judgment calls worth a second pair of eyes:

1. `stl.py`'s module docstring lists DOI 10.2514/6.2025-1895 as a reference, but that DOI resolves to Uzun/Açıkmeşe/Carson's *compound state-triggered constraints* SciTech 2025 paper — not an STL paper. The GMSR nodes therefore cite only arXiv:2405.10996. If a different SciTech paper was intended there, the docstring reference should be fixed separately.

Tests: `walk()` semantics and the `citation()` default in `tests/symbolic/expr/test_expr.py`; node overrides in `test_stl.py` / `test_lie.py`; collection and same-name merging in `tests/symbolic/test_citations.py`; autotuner citations in `tests/algorithms/autotuner/test_citation.py`; and an end-to-end `Problem.citation()` aggregate (sections, headers, dedup) in `tests/test_citation.py`. Docs: a note in the custom-autotuner guide; the API pages pick up the new docstrings automatically.